### PR TITLE
change sbbf_rs usage, fix filter size, use xxhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,8 @@ dependencies = [
  "probabilistic-collections",
  "rand 0.8.5",
  "rand_regex",
- "sbbf-rs",
+ "sbbf-rs-safe",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -270,7 +271,9 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "fastbloom"
-version = "0.3.0"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488af810ad64b53446d732ff54b159c9870cee20b06ff2ebb58b3d265ed1349a"
 dependencies = [
  "rand 0.8.5",
  "siphasher 1.0.0",
@@ -653,6 +656,15 @@ checksum = "5525db49c7719816ac719ea8ffd0d0b4586db1a3f5d3e7751593230dacc642fd"
 dependencies = [
  "cpufeatures",
  "fastrange-rs",
+]
+
+[[package]]
+name = "sbbf-rs-safe"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9902ffeb2cff3f8c072c60c7d526ac9560fc9a66fe1dfc3c240eba5e2151ba3c"
+dependencies = [
+ "sbbf-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ bloomfilter = "1.0.13"
 probabilistic-collections = "0.7.0"
 fastbloom-rs = "0.5.9"
 sbbf-rs-safe = "0.3.2"
-wyhash = "0.5"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
-fastbloom = { path = "../fastbloom" }
+fastbloom = "0.5.1"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/benches/bench_bloom_filter.rs
+++ b/benches/bench_bloom_filter.rs
@@ -18,7 +18,6 @@ use std::collections::HashSet;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::iter::repeat;
-use wyhash::wyhash;
 
 use bloom_filter_benches::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ use std::collections::HashSet;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 use std::iter::repeat;
-use wyhash::wyhash;
 
 #[allow(dead_code)]
 pub fn false_pos_rate_with_vals<X: Hash + Eq + PartialEq>(
@@ -312,7 +311,7 @@ impl Container<String> for fastbloom_rs::BloomFilter {
 impl Container<String> for sbbf_rs_safe::Filter {
     #[inline]
     fn check(&self, s: &String) -> bool {
-        self.contains_hash(wyhash(s.as_bytes(), 0))
+        self.contains_hash(xxhash_rust::xxh3::xxh3_64(s.as_bytes()))
     }
     fn num_hashes(&self) -> usize {
         todo!()
@@ -322,10 +321,10 @@ impl Container<String> for sbbf_rs_safe::Filter {
         items: I,
     ) -> Self {
         let items = items.into_iter();
-        let hashes = bloom::bloom::optimal_num_hashes(num_bits, items.len() as u32);
-        let mut filter = sbbf_rs_safe::Filter::new(hashes as usize, items.len());
+        //let hashes = bloom::bloom::optimal_num_hashes(num_bits, items.len() as u32);
+        let mut filter = sbbf_rs_safe::Filter::new(num_bits, 1);
         for x in items {
-            filter.insert_hash(wyhash(x.as_bytes(), 0));
+            filter.insert_hash(xxhash_rust::xxh3::xxh3_64(x.as_bytes()));
         }
         filter
     }
@@ -337,7 +336,7 @@ impl Container<String> for sbbf_rs_safe::Filter {
 impl Container<u64> for sbbf_rs_safe::Filter {
     #[inline]
     fn check(&self, s: &u64) -> bool {
-        self.contains_hash(wyhash(&s.to_be_bytes(), 0))
+        self.contains_hash(xxhash_rust::xxh3::xxh3_64(&s.to_be_bytes()))
     }
     fn num_hashes(&self) -> usize {
         0
@@ -347,10 +346,9 @@ impl Container<u64> for sbbf_rs_safe::Filter {
         items: I,
     ) -> Self {
         let items = items.into_iter();
-        let hashes = bloom::bloom::optimal_num_hashes(num_bits, items.len() as u32);
-        let mut filter = sbbf_rs_safe::Filter::new(hashes as usize, items.len());
+        let mut filter = sbbf_rs_safe::Filter::new(num_bits, 1);
         for x in items {
-            filter.insert_hash(wyhash(&x.to_be_bytes(), 0));
+            filter.insert_hash(xxhash_rust::xxh3::xxh3_64(&x.to_be_bytes()));
         }
         filter
     }


### PR DESCRIPTION
Filter size in sbbf_rs can be set by just passing num_bits as bits per key and then setting num_keys to 1. This is hacky but should be the right size.

Using xxhash is better for false positives and doesn't change perf much. wyhash has seems to have some problems.